### PR TITLE
DDT-5366 update after internal review

### DIFF
--- a/apis/service-providers/millom-standard-api.yaml
+++ b/apis/service-providers/millom-standard-api.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 servers: 
 - url: https://api.example.millom.com
 info:
-  version: 1.1.0
+  version: 1.2.0
   title: Millom standard service provider API
   description: >-
     This details Millom's standard API for service providers. 

--- a/apis/service-providers/millom-standard-api.yaml
+++ b/apis/service-providers/millom-standard-api.yaml
@@ -382,17 +382,19 @@ components:
       - "resultCode"
       type: object
       properties:
-        resultCode: 
+        subscriberState:
           type: string
-          enum: ["1","2","3"]
+          enum: ["GOOD_TO_GO","NEED_OFFERS","NEED_LOANS", "NEED_TOPUP"]
           description: >
             Aggregated status of user
             
-            * ´1´ - Good to go. User has positive data balance and can use Internet for the service
+            * ´GOOD_TO_GO´ - User has positive data balance and can use Internet for the service
             
-            * ´2´ - Offers available. The user have no activated data plans or low balance, but have offers to purchase. Offers will be populated in the 'offers' array.
-            
-            * '3' - Need topup. No offers was found that user could purchase. The user needs to add funds to his/her account.
+            * ´NEED_OFFERS´ - Offers available. The user have no activated data plans or low balance, but have offers to purchase. Offers will be populated in the 'offers' array.
+
+            * ´NEED_LOANS´ - User is low on data and monetary balance, but is eligible for loan offers. Populated in the 'offers' array
+
+            * 'NEED_TOPUP' - No offers was found that user could purchase. The user needs to add funds to his/her account.
         offers:
           type: array
           items:
@@ -456,7 +458,7 @@ components:
           description: >
             Unique transaction id that must allow a minimum of
             10 alphanumeric characters including dashes and dots. 
-            Preferrably UUID format IETF RFC4122.
+            Preferably UUID format IETF RFC4122.
         planid:
           type: string
           description: >
@@ -480,7 +482,7 @@ components:
           description: >
             Unique transaction id that must allow a minimum of
             10 alphanumeric characters including dashes and dots. 
-            Preferrably UUID format IETF RFC4122.
+            Preferably UUID format IETF RFC4122.
         status:
           type: string
           enum: ["completed", "processing", "failed"]

--- a/apis/service-providers/millom-standard-api.yaml
+++ b/apis/service-providers/millom-standard-api.yaml
@@ -397,17 +397,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Offer"
-        cache:
-          type: object
-          properties:
-            ttl:
-              type: number
-              description: The number of seconds this response is considered to remain valid. Clients may cache this response for this time.
-            cache:
-              type: boolean
-              default: false
-              description: true if this offer was served from millom cache, or false if retrieved directly from operator.
-              
+
     Offer:
       type: object
       properties:

--- a/apis/service-providers/millom-standard-api.yaml
+++ b/apis/service-providers/millom-standard-api.yaml
@@ -34,10 +34,8 @@ paths:
         required: false
         in: query
         schema:
-          type: string
-          enum: [MSISDN, CPID]
-          default: MSISDN
-        description: Type of subscriber ID. MSISDN or CPID.
+          $ref: "#/components/schemas/KeyType"
+        description: Type of subscriber ID. MSISDN, CPID or OPET.
       responses:
         '200':
           description: OK
@@ -76,10 +74,8 @@ paths:
         required: false
         in: query
         schema:
-          type: string
-          enum: [MSISDN, CPID]
-          default: MSISDN
-        description: Type of subscriber ID. MSISDN or CPID.
+          $ref: "#/components/schemas/KeyType"
+        description: Type of subscriber ID. MSISDN, CPID or OPET.
       - name: language
         description: Requested language. Millom will attempt to return strings (plan IDs, descriptions) in this language, otherwise default language (english) will be used.
         required: false
@@ -125,10 +121,8 @@ paths:
         required: false
         in: query
         schema:
-          type: string
-          enum: [MSISDN, CPID]
-          default: MSISDN
-        description: Type of subscriber ID. MSISDN or CPID.
+          $ref: "#/components/schemas/KeyType"
+        description: Type of subscriber ID. MSISDN, CPID or OPET.
       - name: language
         description: Requested language. Millom will attempt to return strings (plan IDs, descriptions) in this language, otherwise default language (english) will be used.
         required: false
@@ -174,10 +168,8 @@ paths:
         required: false
         in: query
         schema:
-          type: string
-          enum: [MSISDN, CPID]
-          default: MSISDN
-        description: Type of subscriber ID. MSISDN or CPID.
+          $ref: "#/components/schemas/KeyType"
+        description: Type of subscriber ID. MSISDN, CPID or OPET.
       - name: language
         required: false
         in: header
@@ -236,10 +228,8 @@ paths:
           required: false
           in: query
           schema:
-            type: string
-            enum: [ MSISDN, CPID ]
-            default: MSISDN
-          description: Type of subscriber ID. MSISDN or CPID.
+            $ref: "#/components/schemas/KeyType"
+          description: Type of subscriber ID. MSISDN, CPID or OPET.
         - name: language
           required: false
           in: header
@@ -276,7 +266,20 @@ paths:
 
 
 components:
-  schemas: 
+  schemas:
+    KeyType:
+      type: string
+      enum: [ MSISDN, CPID, OPET ]
+      default: MSISDN
+      description: >
+        Type of user Identifier. It can hold the following values:
+
+        * ´MSISDN´ - The user's MSISDN number, on full international E.164 form.
+
+        * ´CPID´ - Carrier Plan Identifier. An ID obtained by querying Millom's CPID generator (using the CPID API)
+
+        * ´OPET´ - Operator Encrypted Token. An anonymized token encrypted by the operator and used towards operator APIs.
+
     AccountInfoResponse:
       type: object
       properties:

--- a/apis/service-providers/millom-standard-api.yaml
+++ b/apis/service-providers/millom-standard-api.yaml
@@ -30,12 +30,19 @@ paths:
         description: User identifier string. Can be MSISDN (default), or url-encoded CPID
         schema:
           type: string
-      - name: idType
+      - name: key_type
         required: false
         in: query
         schema:
           $ref: "#/components/schemas/KeyType"
         description: Type of subscriber ID. MSISDN, CPID or OPET.
+      - name: Accept-Language
+        required: false
+        in: header
+        schema:
+          type: string
+        description: Users preferred language, as ISO-639-1 language code.\
+          Millom will try to internationalize strings (eg plan names) to this language, but may return default if wanted language is not configured.
       responses:
         '200':
           description: OK
@@ -70,13 +77,13 @@ paths:
         description: User identifier string. Can be MSISDN (default), or url-encoded CPID
         schema:
           type: string
-      - name: idType
+      - name: key_type
         required: false
         in: query
         schema:
           $ref: "#/components/schemas/KeyType"
         description: Type of subscriber ID. MSISDN, CPID or OPET.
-      - name: language
+      - name: Accept-Language
         description: Requested language. Millom will attempt to return strings (plan IDs, descriptions) in this language, otherwise default language (english) will be used.
         required: false
         in: header
@@ -117,13 +124,13 @@ paths:
         description: User identifier string. Can be MSISDN (default), or url-encoded CPID
         schema:
           type: string
-      - name: idType
+      - name: key_type
         required: false
         in: query
         schema:
           $ref: "#/components/schemas/KeyType"
         description: Type of subscriber ID. MSISDN, CPID or OPET.
-      - name: language
+      - name: Accept-Language
         description: Requested language. Millom will attempt to return strings (plan IDs, descriptions) in this language, otherwise default language (english) will be used.
         required: false
         in: header
@@ -164,13 +171,13 @@ paths:
         description: User identifier string. Can be MSISDN (default), or url-encoded CPID
         schema:
           type: string
-      - name: idType
+      - name: key_type
         required: false
         in: query
         schema:
           $ref: "#/components/schemas/KeyType"
         description: Type of subscriber ID. MSISDN, CPID or OPET.
-      - name: language
+      - name: Accept-Language
         required: false
         in: header
         description: Requested language. Millom will attempt to return strings (plan IDs, descriptions) in this language, otherwise default language (english) will be used.
@@ -224,7 +231,7 @@ paths:
           description: User identifier string. Can be MSISDN (default), or url-encoded CPID
           schema:
             type: string
-        - name: idType
+        - name: key_type
           required: false
           in: query
           schema:
@@ -382,7 +389,7 @@ components:
         
     OfferInfoResponse:
       required:
-      - "resultCode"
+      - "subscriberState"
       type: object
       properties:
         subscriberState:
@@ -498,6 +505,10 @@ components:
         transactionMessage:
           type: string
           description: Textual message from upstream operator
+        confirmationCode:
+          type: string
+          description: Receipt code from operator on successful activations. \
+            Uniquely identifies the activation on operator side.
     
     MultilingualText:
       type: object

--- a/apis/service-providers/millom-standard-api.yaml
+++ b/apis/service-providers/millom-standard-api.yaml
@@ -545,43 +545,20 @@ components:
       type: object
       required: [cause]
       properties:
-        message:
+        errorMessage:
           description: human readable error description
           type: string
         cause:
           description: Error class
           type: string
           enum:
+            - ERROR_CAUSE_UNSPECIFIED
+            - INVALID_NUMBER
             - BAD_REQUEST
-            - PARSING_ERROR
-            - FORBIDDEN
-            - CONFLICT
-            - BAD_CPID
-            - BAD_MSISDN
-            - USER_BARRED
-            - ROAMING
-            - CONGESTED
-            - BE_THROTTLED
-            - OPERATOR_THROTTLED
-            - INVALID_PRODUCT
-            - UNSUPPORTED_OPERATOR
-            - UNKNOWN_SUBSCRIBER_ID
-            - PURCHASE_IN_PROGRESS
-            - PURCHASE_ALREADY_EXECUTED
-            - INSUFFICIENT_FUNDS
-            - FAILURE_IN_BU
-            - CONNECTION_TROUBLE
-            - TIMEOUT
-            - DISABLED
-            - NOT_IMPLEMENTED
-            - KEY_NOT_FOUND
-            - NO_CONSENT
-            - PIN_ENTRY_ERROR
-            - SHUTTING_DOWN
-            - INTERNAL_ERROR
-        opcode:
-          type: string
-          description: Incoming error from backend, if applicable
+            - USER_ROAMING
+            - USER_OPT_OUT
+            - TOO_MANY_REQUESTS
+            - SERVICE_UNAVAILABLE
 
   securitySchemes:
     application:


### PR DESCRIPTION
- rework error handling to only provide ErrorResponse2
- remove cache structure from offer response
- Replace resultCode with subscriberState. And fix some typos
- make keyType a component and refer to it. Support OPET
- replace idType with key_type, which actually is in use
- define Accept-Language header, not language. It’s the header name.
- bug: mentioned SubscriberState but value was called resultCode as previous
- add confirmationCode to ActivationResponse, it’s in use.
- bump api version to 1.2